### PR TITLE
fix ExampleAgent constructor to accept BaseAgent parameters

### DIFF
--- a/agents/example_agent.py
+++ b/agents/example_agent.py
@@ -1,5 +1,6 @@
 import sys
 import os
+from typing import Optional
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from base_agent import BaseAgent
 
@@ -18,8 +19,16 @@ class ExampleAgent(BaseAgent):
     4. Registra el agente en run_agent.py
     """
     
-    def __init__(self, server_url: str = "http://localhost:5000"):
-        super().__init__(server_url, "ExampleAgent")
+    def __init__(self, server_url: str = "http://localhost:5000", 
+                 enable_ui: bool = False,
+                 record_game: bool = False, 
+                 replay_file: Optional[str] = None,
+                 cell_size: int = 60,
+                 fps: int = 10,
+                 auto_exit_on_finish: bool = True,
+                 live_stats: bool = False):
+        super().__init__(server_url, "ExampleAgent", enable_ui, record_game, 
+                        replay_file, cell_size, fps, auto_exit_on_finish, live_stats)
         
         # Estado interno para movimiento circular
         self.movement_sequence = [self.up, self.right, self.down, self.left]


### PR DESCRIPTION
## Summary
  - Fix ExampleAgent constructor to accept all BaseAgent initialization parameters
  - Resolves "Simulation failed: ExampleAgent.__init__() got an unexpected keyword argument 'enable_ui'" error when running with --ui flag

  ## Problem
  The ExampleAgent constructor only accepted `server_url` parameter, but run_agent.py passes all BaseAgent parameters (enable_ui,
  record_game, replay_file, etc.) when instantiating agents. This caused runtime errors when using UI or other features.

  ## Solution
  - Updated ExampleAgent.__init__() to accept all BaseAgent parameters
  - Added proper parameter forwarding to super().__init__()
  - Added missing `from typing import Optional` import

  ## Test Plan
  - [x] Run agent without UI: `python3 run_agent.py --agent-file agents/example_agent.py`
  - [x] Run agent with UI: `python3 run_agent.py --agent-file agents/example_agent.py --ui`

  ## Files Changed
  - `agents/example_agent.py`: Updated constructor signature and added import
